### PR TITLE
Add probability introduction notebook

### DIFF
--- a/probability_intro_project/README.md
+++ b/probability_intro_project/README.md
@@ -1,0 +1,35 @@
+# Introduction to Probability Portfolio Project
+
+This project contains a Jupyter Notebook that explores core concepts from an introductory probability course.  Each section includes a short theoretical description and a practical Python example.
+
+## Contents
+- `probability_intro.ipynb` – notebook with theory and code
+- `requirements.txt` – Python dependencies
+
+## Getting Started
+1. Create a virtual environment (optional)
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Launch the notebook:
+   ```bash
+   jupyter notebook probability_intro.ipynb
+   ```
+
+## Topics Covered
+- Sample spaces and events
+- Law of large numbers
+- Addition and multiplication rules
+- Bayes' theorem
+- Binomial and Poisson distributions
+- Expected value and variance
+- Independence and conditional probability
+- Random variables
+- Combinatorics
+- Cumulative distribution functions
+- Normal distribution
+
+## License
+This project is available under the [MIT License](https://opensource.org/licenses/MIT).
+

--- a/probability_intro_project/probability_intro.ipynb
+++ b/probability_intro_project/probability_intro.ipynb
@@ -1,0 +1,312 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction to Probability\n",
+        "This notebook provides a condensed summary of key concepts from an introductory probability course. Each section pairs theory with a short Python example."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Sets, Sample Spaces & Events\n",
+        "In probability, we use sets to describe the sample space and events. The sample space (S) contains all possible outcomes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "S = set(range(1, 7))\n",
+        "A = {1, 3, 5}\n",
+        "B = {2, 3, 4}\n",
+        "print('Union:', A | B)\n",
+        "print('Intersection:', A & B)\n",
+        "print('Complement of A:', S - A)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Law of Large Numbers (Frequentist Probability)\n",
+        "As the number of trials increases, the empirical probability of an event converges to the true probability."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import random\n",
+        "p = 0.5\n",
+        "hits = 0\n",
+        "for n in range(1, 5001):\n",
+        "    if random.random() < p:\n",
+        "        hits += 1\n",
+        "    if n % 1000 == 0:\n",
+        "        print(n, hits/n)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Addition Rule (Unions)\n",
+        "The probability of (A \u222a B) is P(A) + P(B) - P(A \u2229 B)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "S = set(range(1, 7))\n",
+        "A = {1, 3, 5}\n",
+        "B = {2, 3, 4}\n",
+        "P = len(A|B)/len(S)\n",
+        "print('P(A or B) =', P)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Multiplication (Product) Rule\n",
+        "For independent events, the probability of both occurring is the product of their individual probabilities."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "p_tail = 0.5\n",
+        "print('P(two tails) =', p_tail * p_tail)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Bayes' Theorem\n",
+        "Bayes' theorem allows us to update prior beliefs based on new evidence."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "p_D = 0.01\n",
+        "sens = 0.95\n",
+        "spec = 0.98\n",
+        "p_pos = sens*p_D + (1-spec)*(1-p_D)\n",
+        "print('P(Disease | Positive) =', sens*p_D / p_pos)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Binomial Distribution & PMF\n",
+        "The binomial distribution models the number of successes in a fixed number of independent Bernoulli trials."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from math import comb\n",
+        "def binom_pmf(k, n, p):\n",
+        "    return comb(n, k) * (p**k) * ((1-p)**(n-k))\n",
+        "print('P(X=6) when n=10, p=0.5 ->', binom_pmf(6, 10, 0.5))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Poisson Distribution\n",
+        "The Poisson distribution describes the count of events in a fixed interval when events occur independently at a constant rate."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "def pois_pmf(k, lam):\n",
+        "    return math.exp(-lam)*(lam**k)/math.factorial(k)\n",
+        "def pois_cdf(x, lam):\n",
+        "    return sum(pois_pmf(k, lam) for k in range(x+1))\n",
+        "print('P(X=6) when \u03bb=10 ->', pois_pmf(6, 10))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Expected Value and Variance\n",
+        "For many distributions, the expected value and variance summarize central tendency and spread."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "n, p = 20, 0.3\n",
+        "print('Binomial E,Var:', n*p, n*p*(1-p))\n",
+        "lam = 12\n",
+        "print('Poisson E,Var:', lam, lam)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Independence, Dependence, and Mutual Exclusivity\n",
+        "Dependent events influence each other, while independent events do not."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Dependent draws without replacement (2 blue, 3 red)\n",
+        "p_blue_then_red = (2/5) * (3/4)\n",
+        "print('P(Blue then Red) =', p_blue_then_red)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Conditional Probability\n",
+        "Conditional probability quantifies the probability of one event given that another has occurred."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# P(Red second | Blue first) with 2 blue, 3 red (no replacement)\n",
+        "print('P(Red second | Blue first) =', 3/4)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Random Variables: Discrete vs. Continuous\n",
+        "Random variables map outcomes to numbers; they may be discrete or continuous."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import random\n",
+        "X = random.choice(range(1,7))  # discrete\n",
+        "Y = random.random()             # continuous\n",
+        "print('Discrete:', X, 'Continuous:', Y)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Combinatorics: Combinations & Permutations\n",
+        "Combinatorics helps count possible outcomes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "print('Combinations (10 choose 3):', math.comb(10,3))\n",
+        "print('Permutations (6 permute 2):', math.perm(6,2))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## CDF (Cumulative Distribution Function)\n",
+        "The cumulative distribution function gives the probability of observing a value less than or equal to x."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from math import comb\n",
+        "def binom_pmf(k, n, p):\n",
+        "    return comb(n, k) * (p**k) * ((1-p)**(n-k))\n",
+        "def binom_cdf(x, n, p):\n",
+        "    return sum(binom_pmf(k, n, p) for k in range(x+1))\n",
+        "print('P(X\u22646) when n=10, p=0.5 ->', binom_cdf(6, 10, 0.5))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Normal Distribution & Continuous PDFs\n",
+        "The normal distribution is a continuous distribution characterized by mean and standard deviation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "def norm_cdf(x, mu=0, sigma=1):\n",
+        "    z = (x-mu)/(sigma*math.sqrt(2))\n",
+        "    return 0.5*(1+math.erf(z))\n",
+        "print('P(X\u22641) for standard normal ->', norm_cdf(1))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/probability_intro_project/requirements.txt
+++ b/probability_intro_project/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
## Summary
- add `probability_intro` notebook with theory and Python examples on probability basics
- document project structure with README and requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd4ee098b0832e8a547454c64689bc